### PR TITLE
fix: updates mkdirp version because of a minimist vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "globby": "^6.1.0",
     "graceful-fs": "^4.1.11",
     "meow": "3.7.0",
-    "mkdirp": "0.5.1",
+    "mkdirp": "1.0.4",
     "uglify-es": "^3.1.9",
     "uglify-js": "^3.1.9"
   },


### PR DESCRIPTION
Upgrades `mkdir` to address a vulnerability found in `minimist`.

**What is the purpose of this pull request?** (put an "X" next to item)
- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [x] Other, please explain: updates vulnerable dependency

**What changes did you make?** (Give an overview)
Updated `mkdir` version to 1.0.4 that does not contain the vulnerable version of `minimist`.

=== npm audit security report ===

| Low                    | Prototype Pollution                          |
| ---------------  |:----------------------------------|
| Package             | minimist                                            |
| Dependency of | mkdirp                                               |
| Path                   | mkdirp > minimist                             |
| More info           | https://npmjs.com/advisories/1179 |
