### PR TITLE
Added --redeclare option

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,7 @@
 root = true
 
 [*]
+max_line_length = 80
 indent_style = space
 indent_size = 2
 end_of_line = lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 node_modules
 coverage
 .nyc_output

--- a/cli.js
+++ b/cli.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 'use strict';
 
-var meow = require('meow');
-var uglifyFolder = require('./');
+const meow = require('meow');
+const uglifyFolder = require('./');
 
-var cli = meow({
+const cli = meow({
   help: [
     'Usage',
     '  uglifyjs-folder path [options]',

--- a/cli.js
+++ b/cli.js
@@ -15,6 +15,8 @@ var cli = meow({
     '  -e --each          Minify each file independently',
     '  -x --extension     Minified file extension (default: .min.js)',
     '  -p --pattern       Specifies a comma separated glob patterns for the file selections. Default: **/*.js',
+    '  -d --redeclare     Makes every declaration unique, useful for single output to avoid redeclaration errors.',
+    '                     Don\'t use if it works without.',
     '     --pseparator    Specifies the separator for the pattern input. Default: ,',
     '     --version       Prints the current version from package.json',
     '     --config-file   Specifies a json configuration file for the terser module',
@@ -31,7 +33,8 @@ async function main() {
     extension: cli.flags.extension || cli.flags.x || ".min.js",
     patterns: (cli.flags.pattern || cli.flags.p || "**/*.js").split(cli.flags.pseparator || ','),
     configFile: cli.flags.configFile || null,
-    logLevel: cli.flags.logLevel || 'info'
+    logLevel: cli.flags.logLevel || 'info',
+    redeclare: cli.flags.redeclare || cli.flags.d || false
   });
 
   if (result) {

--- a/cli.js
+++ b/cli.js
@@ -26,7 +26,7 @@ const cli = meow({
 });
 
 async function main() {
-  var result = await uglifyFolder(cli.input[0], {
+  const result = await uglifyFolder(cli.input[0], {
     comments: cli.flags.comments || cli.flags.c || false,
     output: cli.flags.output || cli.flags.o,
     each: cli.flags.each || cli.flags.e || false,

--- a/index.js
+++ b/index.js
@@ -42,10 +42,14 @@ module.exports = async function (dirPath, options) {
     // minify each file individually
     for (const fileName of files) {
       options.output = isEmpty(options.output) ? '_out_' : options.output;
-      const newName = path.join(options.output, path.dirname(fileName), path.basename(fileName, path.extname(fileName))) + options.extension;
+      const newName = path.join(
+        options.output,
+        path.dirname(fileName),
+        path.basename(fileName, path.extname(fileName))) + options.extension;
       originalCode = {};
       originalCode[fileName] = readFile(path.join(dirPath, fileName));
-      minifyResult = await minifier.minify(originalCode, getUglifyOptions(newName, uglifyConfiguration));
+      minifyResult = await minifier.minify(
+        originalCode, getUglifyOptions(newName, uglifyConfiguration));
 
       if (minifyResult.error) {
         console.error(minifyResult.error);
@@ -110,16 +114,18 @@ module.exports = async function (dirPath, options) {
  * @param  {Object} uglifyConfiguration
  * @return {Object}
  */
-function getUglifyOptions (fileName, uglifyConfiguration) {
+function getUglifyOptions(fileName, uglifyConfiguration) {
   fileName = path.basename(fileName);
   const uglifyOptions = JSON.parse(JSON.stringify(uglifyConfiguration));
 
   if (uglifyOptions.sourceMap) {
     if (uglifyOptions.sourceMap.filename) {
-      uglifyOptions.sourceMap.filename = uglifyOptions.sourceMap.filename.replace('{file}', fileName);
+      uglifyOptions.sourceMap.filename =
+        uglifyOptions.sourceMap.filename.replace('{file}', fileName);
     }
     if (uglifyOptions.sourceMap.url) {
-      uglifyOptions.sourceMap.url = uglifyOptions.sourceMap.url.replace('{file}', fileName);
+      uglifyOptions.sourceMap.url =
+        uglifyOptions.sourceMap.url.replace('{file}', fileName);
     }
   }
 
@@ -163,14 +169,14 @@ function writeFile(filePath, code, state) {
       }
     });
   })
-  .catch(function (err) {
-    state.processCounter--;
-    if (state.callback && state.processCounter === 0) {
-      state.callback();
-    }
+    .catch(function (err) {
+      state.processCounter--;
+      if (state.callback && state.processCounter === 0) {
+        state.callback();
+      }
 
-    console.error('Error: ' + err);
-  });
+      console.error('Error: ' + err);
+    });
 
 }
 

--- a/index.js
+++ b/index.js
@@ -125,9 +125,10 @@ module.exports = async function (dirPath, options) {
                 // append to the declaration name a "_"
                 const newName = declared + "_";
                 thoseValues[i] = newName;
-                const findRegex = new RegExp(` ${declared}([^\d\w_$])`, "g");
-                thoseSource = thoseSource.replace(findRegex, ` ${newName}$1`);
+                const findRegex = new RegExp(`([^\d\w_$])${declared}([^\d\w_$])`, "g");
+                thoseSource = thoseSource.replace(findRegex, `$1${newName}$2`);
                 originalCode[thoseFileName] = thoseSource;
+                thoseDeclarations.source = thoseSource;
               }
             }
           }

--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ module.exports = async function (dirPath, options) {
       // Store all declarations in the map, by this we can later on
       // compare if something got redeclared
       declarations.set(fileName, {source: source, declarations: []});
-      for (let match of source.matchAll(/(?:var|let|const)\s+([^=]+)/g)) {
+      for (let match of source.matchAll(/^\s*(?:var|let|const)\s+([^=]+)/gm)) {
         // search for all declarations
         const matched = match[1].trim();
         for (let innerMatched of matched.matchAll(/[^{}[\].,\s]+/g)) {


### PR DESCRIPTION
I added a flag that replaces every declaration that occurs multiple times throughout the source files with the same name but appended with `_`. If multiple files use the same declaration names, it results in declaration names with multiple `_` suffixed.

The detection works via searching for every `const`, `let` or `var` that only has space characters in front of it. After that it takes the part after it until `=`. That also gets inspected to comply with destructuring.

After the detection is done, every declaration name is compared against each other and if two are the same, the duplicate name will be replaced in the whole file. The replacement respects the characters in front of and after the name to ensure that only exactly the declaration name will be replaced and no other identifier with a name close to it. I added no detection for replacements inside of string, if this is wished, I could add that.

All the current tests do still work. But I don't get how the tests here work, therefore I did not add some. Maybe someone can help me out with them.

And lastly, since I'm using WebStorm, I added `.idea` to `.gitignore` and replaced all the `var`s and simplified code where I saw it instantly.

This one fixes #28.